### PR TITLE
ipq8074: fix sddc1 core clk

### DIFF
--- a/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
+++ b/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
@@ -400,14 +400,11 @@
 &sdhc_1 {
 		/* According to the stock dts from the QNAP gpl drop
 		 * the emmc has a problem with the hs400 > hs200 speed switch.
-		 * But at the momment it doesn't seems possible to run that card in hs200 mode,
-		 * it doesn't get recognized without the hs400 mode.
-		 * Unfortunately it's not stable in hs400 mode so reduce the speed to mmc highspeed.
+		 * Therefore remove the mmc-hs400-1_8v property
 		*/
-		no-1-8-v;
-		cap-sd-highspeed;
-		cap-mmc-highspeed;
-		max-frequency   = <5000000>;
+		/delete-property/ mmc-hs400-1_8v;
+		mmc-hs200-1_8v;
+		mmc-ddr-1_8v;
 		vqmmc-supply = <&ldo11>;
 		status = "okay";
 };

--- a/target/linux/ipq807x/patches-5.15/141-fix-sddc1-clk.patch
+++ b/target/linux/ipq807x/patches-5.15/141-fix-sddc1-clk.patch
@@ -1,0 +1,20 @@
+From: Dirk Buchwalder <buchwalder@posteo.de>
+Date: Sun, 16 Jan 2022 13:58:46 +0200
+Subject: [PATCH] arm64: dts: qcom: ipq8074: fix sddc1 core clk
+
+change sdcc1_apps_clk_src to clk_rcg2_floor_ops
+to prevent mmc overclocking as qcom clk framework 
+round up the requested frequency by default for sddc1
+
+Signed-off-by: Dirk Buchwalder <buchwalder@posteo.de>
+--- a/drivers/clk/qcom/gcc-ipq8074.c
++++ b/drivers/clk/qcom/gcc-ipq8074.c
+@@ -1074,7 +1074,7 @@ static struct clk_rcg2 sdcc1_apps_clk_sr
+ 		.name = "sdcc1_apps_clk_src",
+ 		.parent_names = gcc_xo_gpll0_gpll2_gpll0_out_main_div2,
+ 		.num_parents = 4,
+-		.ops = &clk_rcg2_ops,
++		.ops = &clk_rcg2_floor_ops,
+ 	},
+ };
+ 


### PR DESCRIPTION
change sdcc1_apps_clk_src to clk_rcg2_floor_ops
to prevent mmc overclocking as qcom clk framework
round up the requested frequency by default for sddc1

Additionaly it's no longer necessary to reduce the mmc
to highspeed only as hs200 is working now.

Signed-off-by: Dirk Buchwalder <buchwalder@posteo.de>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
